### PR TITLE
[fix] build-pdf クラッシュの修正

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: build pdf and upload release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22
     timeout-minutes: 1
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: yarn
       - name: build pdf
-        run: yarn build:pdf
+        run: yarn build:pdf --no-sandbox
       - name: upload release asset
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: build pdf and upload release
-    runs-on: ubuntu-22
+    runs-on: ubuntu-22.04
     timeout-minutes: 1
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: yarn
       - name: build pdf
-        run: yarn build:pdf --no-sandbox
+        run: yarn build:pdf
       - name: upload release asset
         uses: softprops/action-gh-release@v2
         with:

--- a/pdf-configs/config.js
+++ b/pdf-configs/config.js
@@ -14,4 +14,7 @@ module.exports = {
     "footerTemplate": "<section>\n  <div>\n    <span class=\"pageNumber\"></span>\n    / <span class=\"totalPages\"></span>\n  </div>\n</section>"
   },
   stylesheet_encoding: "utf-8",
+  puppeteerLaunchOptions: {  // Add this object
+    args: ['--no-sandbox', '--disable-setuid-sandbox'] // Inside the object
+  },
 };

--- a/pdf-configs/config.js
+++ b/pdf-configs/config.js
@@ -14,7 +14,4 @@ module.exports = {
     "footerTemplate": "<section>\n  <div>\n    <span class=\"pageNumber\"></span>\n    / <span class=\"totalPages\"></span>\n  </div>\n</section>"
   },
   stylesheet_encoding: "utf-8",
-  puppeteerLaunchOptions: {  // Add this object
-    args: ['--no-sandbox', '--disable-setuid-sandbox'] // Inside the object
-  },
 };


### PR DESCRIPTION
## 概要

build-pdf では、内部で Chromium を使っていますが、ubuntu 24 よりセキュリティ上の制限が強化され動かなくなったようです。

```
[11:17:11] → Failed to launch the browser process!
[1971:1971:0218/[11](https://github.com/kuri-megane/kuri-megane-profile/actions/runs/13389335190/job/37393238522#step:5:12)1710.816693:FATAL:zygote_host_impl_linux.cc(128)] No usable sandbox! If you are running on Ubuntu 23.10+ or another Linux distro that has disabled unprivileged user namespaces with AppArmor, see https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md. Otherwise seehttps://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the (older) SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
[0218/111710.825830:ERROR:file_io_posix.cc(145)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq: No such file or directory (2)
[0218/111710.825871:ERROR:file_io_posix.cc(145)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq: No such file or directory (2)
```

https://github.com/kuri-megane/kuri-megane-profile/actions/runs/13389335190/job/37393238522#step:5:11

Geminiによると、`--no-sandbox` や `--disable-setuid-sandbox` オプションをつけると解消する可能性がありましたが、苦戦していたため、いったん ubuntu 22 に変更します。


```
このエラーメッセージは、md-to-pdf コマンドが Chromium ブラウザをサンドボックス環境で起動できなかったために失敗したことを示しています。これは、特に GitHub Actions のような CI/CD 環境ではよくある問題です。根本的な問題は、Chromium が依存するサンドボックス機構が、セキュリティ上の理由で無効化または制限されていることが多いことです。

エラーの理解

Failed to launch the browser process!: これが主要なエラーです。md-to-pdf は内部で Puppeteer を使用しており、PDF を生成するためにブラウザ (Chromium) が必要です。
No usable sandbox!: これは、ブラウザの起動が失敗した理由を説明しています。Chromium のサンドボックスは、ブラウザプロセスを隔離するセキュリティ機能です。しかし、このサンドボックスには、制限された環境では無効になっていることが多い特定のシステム構成 (ユーザー名前空間など) が必要です。エラーメッセージでは、Ubuntu 23.10 以降と AppArmor が潜在的な原因として具体的に言及されています。
/sys/devices/system/cpu/cpu0/cpufreq/...: これらのエラーは、根本原因ではなく、ブラウザの起動失敗の結果である可能性が高いです。Puppeteer は CPU 周波数情報にアクセスしようとしている可能性がありますが、主要なプロセスがすでにクラッシュしているため、これは失敗します。
**[DEP0040] DeprecationWarning: The \punycode` module is deprecated**: これは別の警告であり、エラーではありません。最終的には対処する必要があります (punycode` を使用する依存関係を更新することで) が、PDF 生成が失敗している理由ではありません。
```

## 動作確認

https://github.com/kuri-megane/kuri-megane-profile/actions/runs/13389770672