### PR TITLE
[fix] Ubuntu 24 で md-to-pdf が起動しない問題を修正 (#8)

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: build pdf and upload release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
       - uses: actions/checkout@v4

--- a/pdf-configs/config.js
+++ b/pdf-configs/config.js
@@ -6,6 +6,9 @@ module.exports = {
     smartypants: true,
   },
   dest: "./docs/resume.pdf",
+  launch_options: {
+    args: ["--no-sandbox", "--disable-setuid-sandbox"],
+  },
   pdf_options: {
     "format": "A4",
     "margin": "30mm 20mm",


### PR DESCRIPTION
## 概要

Issue #8 の根本対応。

Ubuntu 23.10+ では AppArmor によって unprivileged user namespaces が制限され、md-to-pdf 内部の Chromium が起動できなくなっていた。
PR #7 では `ubuntu-22.04` への固定で回避していたが、本 PR で恒久的に修正する。

## 変更内容

- `pdf-configs/config.js`: Puppeteer の `launch_options` に `--no-sandbox` / `--disable-setuid-sandbox` を追加
- `.github/workflows/build-pdf.yml`: `ubuntu-22.04` → `ubuntu-latest` に変更

## 動作確認

- ローカルで `yarn build:pdf` を実行し、PDF が正常に生成されることを確認済み

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)