### PR TITLE
[fix] CI ビルドの PDF 文字化けを修正

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: build pdf and upload release
     runs-on: ubuntu-latest
-    timeout-minutes: 1
+    timeout-minutes: 3
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -19,6 +19,8 @@ jobs:
           cache: yarn
       - name: Install dependencies
         run: yarn
+      - name: Install Japanese fonts
+        run: sudo apt-get install -y fonts-noto-cjk
       - name: build pdf
         run: yarn build:pdf
       - name: upload release asset

--- a/pdf-configs/style.css
+++ b/pdf-configs/style.css
@@ -1,8 +1,6 @@
-@import url(//fonts.googleapis.com/earlyaccess/notosansjapanese.css);
-
 body {
   font-size: 12px;
-  font-family: "Noto Sans Japanese", "Hiragino Kaku Gothic ProN", Meiryo, sans-serif;
+  font-family: "Noto Sans CJK JP", "Noto Sans Japanese", "Hiragino Kaku Gothic ProN", Meiryo, sans-serif;
 }
 
 h1:first-child {


### PR DESCRIPTION
## Summary

- CI の Ubuntu 環境で日本語フォントが存在しないため PDF が文字化けしていた問題を修正
- `style.css` からプロトコル相対 URL による Google Fonts 外部インポートを削除（Puppeteer のヘッドレス環境で解決失敗する）
- `"Noto Sans CJK JP"` を font-family の第一候補に変更
- `.github/workflows/build-pdf.yml` に `fonts-noto-cjk` のインストールステップを追加

## Test plan

- [ ] CI でタグプッシュ後、リリースアセットの PDF を開いて日本語が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)